### PR TITLE
내부망 도메인 사용 설정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Greenfinch Ruby Library
 ![](https://upload.wikimedia.org/wikipedia/commons/3/32/Carduelis_chloris_3_%28Marek_Szczepanek%29.jpg)
 
-한국신용데이터 data lake로 서비스 내 각종 event를 전송하는 ruby library 입니다. 
+한국신용데이터 data lake로 서비스 내 각종 event를 전송하는 ruby library 입니다.
 
 ## 설치하기
 ```sh
@@ -21,7 +21,7 @@ ___
 greenfinch tracker를 초기화 하는 함수입니다. 아래와 같이 초기화 후 사용하시기 바랍니다.
 
 ```ruby
-tracker = Greenfinch::Tracker.new('<YOUR TOKEN>', '<YOUR SERVICE>', true)
+tracker = Greenfinch::Tracker.new('<YOUR TOKEN>', '<YOUR SERVICE>', true, use_internal_domain: true)
 ```
 
 | Argument | Type | Description |
@@ -30,6 +30,7 @@ tracker = Greenfinch::Tracker.new('<YOUR TOKEN>', '<YOUR SERVICE>', true)
 | **service_name** | <span class="mp-arg-type">String, </span></br></span><span class="mp-arg-required">required</span> | 부여받은 service name |
 | **debug** | <span class="mp-arg-type">Boolean, </span></br></span><span class="mp-arg-required">required</span> | true: staging, false: production |
 | **error_handler** | <span class="mp-arg-type">Greenfinch::ErrorHandler, </span></br></span><span class="mp-arg-required">optional</span> | error handler |
+| **use_internal_domain** | <span class="mp-arg-type">Boolean, </span></br></span><span class="mp-arg-required">optional</span> | true: internal (private) domain, false: public domain |
 
 
 ___

--- a/lib/greenfinch-ruby/consumer.rb
+++ b/lib/greenfinch-ruby/consumer.rb
@@ -88,11 +88,20 @@ module Greenfinch
       jwt_token = decoded_message["jwt_token"]
       service_name = decoded_message["service_name"]
       debug = decoded_message["debug"]
+      use_internal_domain = decoded_message["use_internal_domain"]
 
       if debug == true
-        endpoint = "https://event-staging.kcd.partners/api/publish/#{service_name}"
+        if use_internal_domain
+          endpoint = "https://internal-event-staging.kcd.partners/api/publish/#{service_name}"
+        else
+          endpoint = "https://event-staging.kcd.partners/api/publish/#{service_name}"
+        end
       else
-        endpoint = "#{endpoint}/#{service_name}"
+        if use_internal_domain
+          endpoint = "https://internal-event.kcd.partners/api/publish/#{service_name}"
+        else
+          endpoint = "#{endpoint}/#{service_name}"
+        end
       end
 
       form_data = decoded_message["data"]

--- a/lib/greenfinch-ruby/consumer.rb
+++ b/lib/greenfinch-ruby/consumer.rb
@@ -87,22 +87,8 @@ module Greenfinch
       decoded_message = JSON.load(message)
       jwt_token = decoded_message["jwt_token"]
       service_name = decoded_message["service_name"]
-      debug = decoded_message["debug"]
-      use_internal_domain = decoded_message["use_internal_domain"]
 
-      if debug == true
-        if use_internal_domain
-          endpoint = "https://internal-event-staging.kcd.partners/api/publish/#{service_name}"
-        else
-          endpoint = "https://event-staging.kcd.partners/api/publish/#{service_name}"
-        end
-      else
-        if use_internal_domain
-          endpoint = "https://internal-event.kcd.partners/api/publish/#{service_name}"
-        else
-          endpoint = "#{endpoint}/#{service_name}"
-        end
-      end
+      endpoint = "#{endpoint}/#{service_name}"
 
       form_data = decoded_message["data"]
 

--- a/lib/greenfinch-ruby/events.rb
+++ b/lib/greenfinch-ruby/events.rb
@@ -22,11 +22,12 @@ module Greenfinch
     #     # tracker has all of the methods of Greenfinch::Events
     #     tracker = Greenfinch::Tracker.new(YOUR_GREENFINCH_TOKEN)
     #
-    def initialize(token, service_name, debug, error_handler=nil, &block)
+    def initialize(token, service_name, debug, error_handler=nil, use_internal_domain: false, &block)
       @token = token
       @service_name = service_name
       @debug = debug
       @error_handler = error_handler || ErrorHandler.new
+      @use_internal_domain = use_internal_domain
 
       if block
         @sink = block
@@ -71,7 +72,8 @@ module Greenfinch
         'data' => data,
         'jwt_token' => @token,
         'service_name' => @service_name,
-        'debug' => @debug
+        'debug' => @debug,
+        'use_internal_domain' => @use_internal_domain,
       }
 
       ret = true

--- a/lib/greenfinch-ruby/tracker.rb
+++ b/lib/greenfinch-ruby/tracker.rb
@@ -52,8 +52,8 @@ module Greenfinch
     # If a block is provided, it is passed a type (one of :event or :profile_update)
     # and a string message. This same format is accepted by Greenfinch::Consumer#send!
     # and Greenfinch::BufferedConsumer#send!
-    def initialize(token, service_name, debug, error_handler=nil, &block)
-      super(token, service_name, debug, error_handler, &block)
+    def initialize(token, service_name, debug, error_handler=nil, use_internal_domain: false, &block)
+      super(token, service_name, debug, error_handler, use_internal_domain: use_internal_domain, &block)
       @token = token
       @service_name = service_name
       @debug = debug

--- a/lib/greenfinch-ruby/version.rb
+++ b/lib/greenfinch-ruby/version.rb
@@ -1,3 +1,3 @@
 module Greenfinch
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
https://app.clubhouse.io/korea-credit-data/story/8063

하위 호환을 유지하기 위해 `Tracker#initialize` 에 `use_internal_domain: false` 키워드 인자를 추가합니다.